### PR TITLE
230805/정윤석/아이템과 플레이어 데이터 연결

### DIFF
--- a/Assets/Data/Json/Item2.json
+++ b/Assets/Data/Json/Item2.json
@@ -1,0 +1,19 @@
+﻿{
+    "item": [
+      {
+        "itemIdx": 1,
+        "name": "센트리볼",
+        "rank": 0,
+        "price": 250,
+        "script": "범위 #ar# (공격범위 120%) 내의 적을 자동으로 감지하여 #as# (공격속도 150%) 의 공격속도로 #at# (공격력 50%) 피해를 입히는 광선을 발사하는 구체 드론.",
+        "imgIdx": 1,
+        "category": 0,
+        "attackPowerCalc": true,
+        "attackPowerValue": 0.50,
+        "attackSpeedCalc": true,
+        "attackSpeedValue": 1.20,
+        "attackRangeCalc": true,
+        "attackRangeValue": 1.50
+      }
+    ]
+}

--- a/Assets/Data/Json/Item2.json.meta
+++ b/Assets/Data/Json/Item2.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 72052617d148c6b44b12cdb4166b1ea6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Scripts/Item.cs
+++ b/Assets/Data/Scripts/Item.cs
@@ -10,7 +10,7 @@ public class ItemList {
 }
 
 
-[SerializeField]
+[Serializable]
 public class Item {
     public int itemIdx;
     public string name;

--- a/Assets/Data/Scripts/Player.cs
+++ b/Assets/Data/Scripts/Player.cs
@@ -10,6 +10,8 @@ public class Player {
     public int reqExp;
     public int curExp;
     public int money;
+    public int startMoney;
+    public float earnMoney;
 
     // status
     public double maxHp;

--- a/Assets/Scenes/Night/NightScene.unity
+++ b/Assets/Scenes/Night/NightScene.unity
@@ -787,7 +787,8 @@ MonoBehaviour:
   characterParent: {fileID: 182467907}
   character: {fileID: 889106807}
   hitBox: {fileID: 1410340655}
-  itemIdxArr: 000000000000000000000000
+  itemIdxArr: 040000000000000000000000
+  itemRankArr: 000000000000000000000000
   tempItemIdx: 5
   itemPrefabArr:
   - {fileID: 0}
@@ -1217,7 +1218,7 @@ MonoBehaviour:
   traitJsonName: TraitTrashJsonData
   nowLevel: 0
   traitIndexList: 
-  traitList: []
+  traitOldList: []
   testTraitIndex: 0
   arr: []
 --- !u!1 &799972125
@@ -3277,7 +3278,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &2022676908
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3756,11 +3757,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3514429689775917780, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
       propertyPath: m_SpriteTilingProperty.oldSize.x
-      value: 6
+      value: 2.5
       objectReference: {fileID: 0}
     - target: {fileID: 3514429689775917780, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
       propertyPath: m_SpriteTilingProperty.oldSize.y
-      value: 6
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3514429689775917782, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
       propertyPath: m_LocalScale.y
@@ -3802,6 +3803,10 @@ PrefabInstance:
       propertyPath: shieldBarImage
       value: 
       objectReference: {fileID: 1406309405}
+    - target: {fileID: 3514429690322398364, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3514429690322398365, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
       propertyPath: m_FlipY
       value: 0

--- a/Assets/Scenes/Night/Script/Class/Character.cs
+++ b/Assets/Scenes/Night/Script/Class/Character.cs
@@ -33,8 +33,8 @@ public class Character : MonoBehaviour
 
     //캐릭터 임시 데이터
     [SerializeField]
-    CharacterTrashData characterData;
-    //Player characterData;
+    //CharacterTrashData characterData;
+    Player characterData;
     [SerializeField]
     bool isCheat;
 
@@ -60,8 +60,10 @@ public class Character : MonoBehaviour
     private Animator animator;
 
     private void Awake() {
-        characterData = new CharacterTrashData(isCheat);
-        //characterData = GameManager.instance.player;
+        //characterData = new CharacterTrashData(isCheat);
+        GameManager.instance.LoadPlayerData();          //임시코드@@@@@@@@@@@@@
+
+        characterData = GameManager.instance.player;
         characterRigid = this.GetComponent<Rigidbody2D>();
         characterSpriteRanderer = GetComponent<SpriteRenderer>();
         animator = GetComponent<Animator>();
@@ -394,6 +396,7 @@ public class Character : MonoBehaviour
         else { // 체력으로 데미지 받을 때
             //Hp - 적 데미지 계산
             if (characterData.curHp > getAttackData) {
+                Debug.Log("damaged");
                 characterData.curHp -= getAttackData;
                 hpBarImage.fillAmount = (float)characterData.curHp / (float)characterData.maxHp;
             }

--- a/Assets/Scenes/Night/Script/Class/Enemy/EnemyParent.cs
+++ b/Assets/Scenes/Night/Script/Class/Enemy/EnemyParent.cs
@@ -189,7 +189,7 @@ public class EnemyParent : MonoBehaviour
 
         else if(collision.name == "CentryBallProjPrefab(Clone)")
         {
-            getDamage = character.GetComponent<Character>().ReturnCharacterAttackPower();
+            getDamage = collision.GetComponent<Projectile>().projPower;
         }
 
         else if (collision.tag == "Item")

--- a/Assets/Scenes/Night/Script/Class/Enemy/Projectile.cs
+++ b/Assets/Scenes/Night/Script/Class/Enemy/Projectile.cs
@@ -6,6 +6,8 @@ using UnityEngine.UIElements;
 public class Projectile : MonoBehaviour
 {
     public bool isEnemy;
+    public float projPower;
+
     private void OnTriggerEnter2D(Collider2D collision)
     {
         if (isEnemy)

--- a/Assets/Scenes/Night/Script/Class/Item/CentryBall.cs
+++ b/Assets/Scenes/Night/Script/Class/Item/CentryBall.cs
@@ -21,6 +21,11 @@ public class CentryBall : MonoBehaviour
     int pullingScale = 30;
     int nowPullingIndex = 0;
 
+    int itemRank;
+    float attackRangeRate;
+    float attackSpeedRate;
+    float attackPowerRate;
+
     Vector3 watchDir = Vector3.zero;
     bool isShoot = false;
     bool isStop = false;
@@ -28,6 +33,10 @@ public class CentryBall : MonoBehaviour
     LayerMask enemyLayer;
     [SerializeField]
     float detectRadius;
+    [SerializeField]
+    float shootTime;
+    [SerializeField]
+    float projPower;
 
     private void Awake()
     {
@@ -37,9 +46,43 @@ public class CentryBall : MonoBehaviour
 
     private void Start()
     {
+        SetCentryBallData();
         SetProjectile();
-
     }
+
+    public void SetItemRank(int getRank)
+    {
+        itemRank = getRank;
+    }
+
+    void SetCentryBallData()
+    {
+        switch(itemRank)
+        {
+            case 0:
+                attackRangeRate = (float)DataManager.instance.itemList.item[0].attackRangeValue;
+                attackSpeedRate = (float)DataManager.instance.itemList.item[0].attackSpeedValue;
+                attackPowerRate = (float)DataManager.instance.itemList.item[0].attackPowerValue;
+                break;
+            case 1:
+                attackRangeRate = (float)DataManager.instance.itemList.item[15].attackRangeValue;
+                attackSpeedRate = (float)DataManager.instance.itemList.item[15].attackSpeedValue;
+                attackPowerRate = (float)DataManager.instance.itemList.item[15].attackPowerValue;
+                break;
+            case 2:
+                attackRangeRate = (float)DataManager.instance.itemList.item[30].attackRangeValue;
+                attackSpeedRate = (float)DataManager.instance.itemList.item[30].attackSpeedValue;
+                attackPowerRate = (float)DataManager.instance.itemList.item[30].attackPowerValue;
+                break;
+            case 3:
+                attackRangeRate = (float)DataManager.instance.itemList.item[45].attackRangeValue;
+                attackSpeedRate = (float)DataManager.instance.itemList.item[45].attackSpeedValue;
+                attackPowerRate = (float)DataManager.instance.itemList.item[45].attackPowerValue;
+                break;
+        }
+        projPower = (float)character.ReturnCharacterAttackPower() * attackPowerRate;
+    }
+
     //공격 함수 들어갈 예정 + 범위는 overlap
     void SetProjectile()
     {
@@ -50,6 +93,7 @@ public class CentryBall : MonoBehaviour
         {
             GameObject nowProj = Instantiate(projectileObject, this.transform);
             nowProj.GetComponent<Projectile>().isEnemy = false;
+            nowProj.GetComponent<Projectile>().projPower = projPower;
             nowProj.transform.SetParent(this.transform.GetChild(1));
             nowProj.transform.position = centryBallImage.transform.position;
             nowProj.SetActive(false);
@@ -103,6 +147,9 @@ public class CentryBall : MonoBehaviour
     {
         int layerMask = (1 << enemyLayer);
         Collider2D shortestCol = null;
+        detectRadius = (float)character.ReturnCharacterAttackRange() * 15 * 0.01f * attackRangeRate;
+        shootTime = 10 / ((float)character.ReturnCharacterAttackSpeed() * attackSpeedRate);
+
         while (!nightManager.isStageEnd)
         { 
             Collider2D[] colArr = Physics2D.OverlapCircleAll(character.transform.position, detectRadius, layerMask);
@@ -114,7 +161,7 @@ public class CentryBall : MonoBehaviour
                 ShootProjectile(shortestCol);
             }
 
-            yield return new WaitForSeconds(1f);
+            yield return new WaitForSeconds(shootTime);
         }
     }
 

--- a/Assets/Scenes/Night/Script/Class/Item/ChargingReaper.cs
+++ b/Assets/Scenes/Night/Script/Class/Item/ChargingReaper.cs
@@ -8,7 +8,33 @@ public class ChargingReaper : MonoBehaviour
     GameObject reaperAfterImage;
     public bool isAttack = false;
     public int chargingGauge = 100;
-    public double reaperAttackDamaege = 500; //임시
+    public double reaperAttackDamaege; //임시
+    int itemRank;
+
+    public void SetItemRank(int getRank)
+    {
+        itemRank = getRank;
+        SetChargingReaperData();
+    }
+
+    void SetChargingReaperData()
+    {
+        switch (itemRank)
+        {
+            case 0:
+                reaperAttackDamaege = 13;
+                break;
+            case 1:
+                reaperAttackDamaege = 18;
+                break;
+            case 2:
+                reaperAttackDamaege = 27;
+                break;
+            case 3:
+                reaperAttackDamaege = 42;
+                break;
+        }
+    }
 
     public bool IsChargingGaugeFull()
     {

--- a/Assets/Scenes/Night/Script/Class/Item/DisasterDrone.cs
+++ b/Assets/Scenes/Night/Script/Class/Item/DisasterDrone.cs
@@ -13,11 +13,46 @@ public class DisasterDrone : MonoBehaviour
     [SerializeField]
     double damage;
 
+    int itemRank;
+    float getAttackRangeValue;
+    float enemyDamageRate;
+
     EnemyParent getEnemyScript;
 
     private void Start()
     {
         DetectEnemy();
+    }
+
+    public void SetItemRank(int getRank)
+    {
+        itemRank = getRank;
+        SetDisasterDroneData();
+    }
+
+    void SetDisasterDroneData()
+    {
+        getAttackRangeValue = (float)DataManager.instance.itemList.item[2].attackRangeValue;
+
+        switch (itemRank)
+        {
+            case 0:
+                detectRadius = (float)character.ReturnCharacterAttackRange() * 0.15f * getAttackRangeValue;
+                enemyDamageRate = 0.05f;
+                break;
+            case 1:
+                detectRadius = (float)character.ReturnCharacterAttackRange() * 0.15f * getAttackRangeValue;
+                enemyDamageRate = 0.08f;
+                break;
+            case 2:
+                detectRadius = (float)character.ReturnCharacterAttackRange() * 0.15f * getAttackRangeValue;
+                enemyDamageRate = 0.12f;
+                break;
+            case 3:
+                detectRadius = (float)character.ReturnCharacterAttackRange() * 0.15f * getAttackRangeValue;
+                enemyDamageRate = 0.16f;
+                break;
+        }
     }
 
     void DetectEnemy()
@@ -49,7 +84,7 @@ public class DisasterDrone : MonoBehaviour
         getEnemyScript = getCol.GetComponent<EnemyParent>();
         damage = getEnemyScript.ReturnEnemyHitPointMax();
 
-        damage /= 1;
+        damage *= enemyDamageRate;
 
         getEnemyScript.EnemyDamaged(damage);
     }

--- a/Assets/Scenes/Night/Script/Class/Item/RailPiercer.cs
+++ b/Assets/Scenes/Night/Script/Class/Item/RailPiercer.cs
@@ -23,11 +23,33 @@ public class RailPiercer : MonoBehaviour
     bool isWatchRight = true;
     bool isShoot = false;
 
+    int itemRank;
+
     private void OnTriggerEnter2D(Collider2D collision)
     {
         if (collision.tag == "Normal" || collision.tag == "Elite")
         {
             collision.GetComponent<EnemyParent>().EnemyDamaged(attackPower);
+        }
+    }
+
+    public void SetItemRank(int getRank)
+    {
+        itemRank = getRank;
+    }
+
+    void SetChargingReaperData()
+    {
+        switch (itemRank)
+        {
+            case 0:
+                break;
+            case 1:
+                break;
+            case 2:
+                break;
+            case 3:
+                break;
         }
     }
 

--- a/Assets/Scenes/Night/Script/Class/Item/SwordAura.cs
+++ b/Assets/Scenes/Night/Script/Class/Item/SwordAura.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class SwordAura : MonoBehaviour
 {
-    double attackDamage = 500;
+    public double attackDamage = 500;
 
     private void OnTriggerEnter2D(Collider2D collision)
     {

--- a/Assets/Scenes/Night/Script/Manager/ItemManager.cs
+++ b/Assets/Scenes/Night/Script/Manager/ItemManager.cs
@@ -30,6 +30,8 @@ public class ItemManager : MonoBehaviour
     [SerializeField]
     int[] itemIdxArr;
     [SerializeField]
+    int[] itemRankArr;
+    [SerializeField]
     int tempItemIdx;
 
     [SerializeField]
@@ -63,20 +65,31 @@ public class ItemManager : MonoBehaviour
     }
 
     //아이템 체크하려고 만든 임시 코드
-    void SetTempItem1()
+    //void SetTempItem1()
+    //{
+    //    FindItem(tempItemIdx);
+    //}
+
+    void SetItemIdxArr()
     {
-        FindItem(tempItemIdx);
+        for (int i = 0; i < GameManager.instance.player.item.Length; i++)
+        {
+            itemIdxArr[i] = GameManager.instance.player.item[i].itemIdx;
+            itemRankArr[i] = GameManager.instance.player.item[i].rank;
+            itemIdxArr[i] -= (itemRankArr[i] * 15);     //아이템 인덱스로 ItemName을 구분하기 때문에 강제로 만든 식입니다.
+                                                        //아이템 인덱스 - 랭크*15 = itemName
+        }
     }
 
     void StartItem()
     {
         for(int i =0; i< itemIdxArr.Length; i++)
         {
-            FindItem(itemIdxArr[i]);
+            FindItem(itemIdxArr[i], itemRankArr[i]);
         }
     }
 
-    void FindItem(int getIdx)
+    void FindItem(int getIdx, int getRank)
     {
         ItemName nowItemName = (ItemName)getIdx;
         Debug.Log(nowItemName.ToString());
@@ -85,59 +98,60 @@ public class ItemManager : MonoBehaviour
             case ItemName.None:
                 break;
             case ItemName.CentryBall:
-                StartCoroutine(CentryBallCoroutine());
+                StartCoroutine(CentryBallCoroutine(getRank));
                 break;
             case ItemName.ChargingReaper:
-                StartCoroutine(ChargingReaperCoroutine());
+                StartCoroutine(ChargingReaperCoroutine(getRank));
                 break;
             case ItemName.DisasterDrone:
-                DisasterDrone();
+                DisasterDrone(getRank);
                 break;
             case ItemName.MultiSlash:
-                StartCoroutine(MultiSlashCoroutine());
+                StartCoroutine(MultiSlashCoroutine(getRank));
                 break;
             case ItemName.RailPiercer:
-                RailPiercer();
+                RailPiercer(getRank);
                 break;
             case ItemName.FirstAde:
-                StartCoroutine(FirstAdeCoroutine());
+                StartCoroutine(FirstAdeCoroutine(getRank));
                 break;
             case ItemName.Barrior:
-                StartCoroutine(BarriorCoroutine());
+                StartCoroutine(BarriorCoroutine(getRank));
                 break;
             case ItemName.HologramTrick:
-                StartCoroutine(HologramTrickCoroutine());
+                StartCoroutine(HologramTrickCoroutine(getRank));
                 break;
             case ItemName.AntiPhenet:
-                AntiPhenet();
+                AntiPhenet(getRank);
                 break;
             case ItemName.RegenerationArmor:
-                RegenerationArmor();
+                RegenerationArmor(getRank);
                 break;
             case ItemName.GravityBind:
-                GravityBind();
+                GravityBind(getRank);
                 break;
             case ItemName.MoveBack:
-                StartCoroutine(MoveBack());
+                StartCoroutine(MoveBack(getRank));
                 break;
             case ItemName.Booster:
-                StartCoroutine(BoosterCoroutine());
+                StartCoroutine(BoosterCoroutine(getRank));
                 break;
             case ItemName.BioSnach:
-                BioSnach();
+                BioSnach(getRank);
                 break;
             case ItemName.InterceptDrone:
-                InterceptDroneCoroutine();
+                InterceptDroneCoroutine(getRank);
                 break;
         }
     }
 
-    IEnumerator CentryBallCoroutine()
+    IEnumerator CentryBallCoroutine(int getitemRank)
     {
         GameObject centryBallParent = Instantiate(itemPrefabArr[1]);
         GameObject centryBall = centryBallParent.transform.GetChild(0).gameObject;
         CentryBall centryBallScript = centryBallParent.GetComponent<CentryBall>();
         centryBallParent.transform.SetParent(character.transform);
+        centryBallScript.SetItemRank(getitemRank);
 
         Vector3 centryBallPos = character.transform.position;
         centryBallPos.y += 7;
@@ -154,12 +168,13 @@ public class ItemManager : MonoBehaviour
         }
     }
 
-    IEnumerator ChargingReaperCoroutine()
+    IEnumerator ChargingReaperCoroutine(int getRank)
     {
         isChargingReaperUse = true;
         GameObject chargingReaperParent = Instantiate(itemPrefabArr[2]);
         chargingReaperParent.transform.SetParent(characterParent.transform);
         chargingReaperScript = chargingReaperParent.GetComponent<ChargingReaper>();
+        chargingReaperScript.SetItemRank(getRank);
 
         Transform reaperImageTransform = chargingReaperParent.transform.GetChild(0);
 
@@ -195,17 +210,38 @@ public class ItemManager : MonoBehaviour
             chargingReaperScript.ChargingGauge();
     }
 
-    void DisasterDrone()
+    void DisasterDrone(int getRank)
     {
         GameObject disasterDroneParent = Instantiate(itemPrefabArr[3]);
         disasterDroneParent.transform.SetParent(character.transform);
         disasterDroneParent.transform.localPosition = character.transform.position;
         disasterDroneParent.GetComponent<DisasterDrone>().character = character;
         disasterDroneParent.GetComponent<DisasterDrone>().nightManager = nightManager;
+        disasterDroneParent.GetComponent<DisasterDrone>().SetItemRank(getRank);
     }
 
-    IEnumerator MultiSlashCoroutine()
+    IEnumerator MultiSlashCoroutine(int getRank)
     {
+        //랭크에 따라 다른 작업 추가
+        float slashTime = 6;
+        float attackPowerRate = (float)DataManager.instance.itemList.item[3].attackPowerValue;
+        float slashAttackPower = (float)character.ReturnCharacterAttackPower() * attackPowerRate;
+
+        switch (getRank)
+        {
+            case 0:
+                slashTime = 6;
+                break;
+            case 1:
+                slashTime = 5;
+                break;
+            case 2:
+                slashTime = 4;
+                break;
+            case 3:
+                slashTime = 3;
+                break;
+        }
 
         //2회 연속공격 + 에너지파
         while (!nightManager.isStageEnd)
@@ -217,9 +253,9 @@ public class ItemManager : MonoBehaviour
                 yield return null;
             }
             Debug.Log("end");
-            ShootSwordAura();
+            ShootSwordAura(slashAttackPower);
 
-            yield return new WaitForSeconds(6);
+            yield return new WaitForSeconds(slashTime);
         }
     }
 
@@ -233,11 +269,12 @@ public class ItemManager : MonoBehaviour
             hitBoxSpriteRenderer.sprite = multiSlasherSprite[1];   //멀티 슬레쉬 스프라이트
     }
 
-    void ShootSwordAura()
+    void ShootSwordAura(float getSlashAttackPower)
     {
         GameObject swordAura = Instantiate(itemPrefabArr[4]);
         swordAura.transform.SetParent(characterParent.transform);
         swordAura.transform.position = hitBox.transform.position;
+        swordAura.GetComponent<SwordAura>().attackDamage = getSlashAttackPower;
 
         //Color swordAuraColor = Color.blue;
         //swordAuraColor.a = 0.5f;
@@ -269,7 +306,7 @@ public class ItemManager : MonoBehaviour
         }
     }
 
-    void RailPiercer()
+    void RailPiercer(int getRank)
     {
         GameObject railPiercerParent = Instantiate(itemPrefabArr[5]);
         railPiercerParent.transform.SetParent(characterParent.transform);
@@ -277,6 +314,7 @@ public class ItemManager : MonoBehaviour
 
         railPiercerScript.character = character;
         railPiercerScript.nightManager = nightManager;
+        railPiercerScript.SetItemRank(getRank);
 
         double characterAttackSpeed = character.ReturnCharacterAttackSpeed();
         double characterAttackPower = character.ReturnCharacterAttackPower();
@@ -285,7 +323,7 @@ public class ItemManager : MonoBehaviour
         railPiercerScript.ShootRailPiercer(characterAttackSpeed, characterAttackPower);
     }
 
-    IEnumerator FirstAdeCoroutine()
+    IEnumerator FirstAdeCoroutine(int getRank)
     {
         GameObject firstAdeParent = Instantiate(itemPrefabArr[6]);
         firstAdeParent.transform.SetParent(character.transform);
@@ -310,7 +348,7 @@ public class ItemManager : MonoBehaviour
         }
     }
 
-    IEnumerator BarriorCoroutine()
+    IEnumerator BarriorCoroutine(int getRank)
     {
         GameObject barriorParent = Instantiate(itemPrefabArr[7]);
         barriorParent.transform.SetParent(character.transform);
@@ -334,7 +372,7 @@ public class ItemManager : MonoBehaviour
         }
     }
 
-    IEnumerator HologramTrickCoroutine()
+    IEnumerator HologramTrickCoroutine(int getRank)
     {
         GameObject[] hologramParentArr = new GameObject[2];
         Vector3 hologramVector;
@@ -375,12 +413,12 @@ public class ItemManager : MonoBehaviour
         }
     }
 
-    void AntiPhenet()
+    void AntiPhenet(int getRank)
     {
         character.isAntiPhenetOn = true;
     }
 
-    void RegenerationArmor()
+    void RegenerationArmor(int getRank)
     {
         double addHp = character.ReturnCharacterAttackPower();
         double addHpRegen = character.ReturnCharacterAttackRange();
@@ -392,7 +430,7 @@ public class ItemManager : MonoBehaviour
         character.SetCharacterHpRegen(addHpRegen);
     }
 
-    void GravityBind()
+    void GravityBind(int getRank)
     {
         GameObject gravityBindParent = Instantiate(itemPrefabArr[11]);
         gravityBindParent.transform.SetParent(characterParent.transform);
@@ -401,7 +439,7 @@ public class ItemManager : MonoBehaviour
         gravityBindParent.transform.GetChild(0).GetComponent<GravityBind>().nightManager = nightManager;
     }
 
-    IEnumerator MoveBack()
+    IEnumerator MoveBack(int getRank)
     {
         double getAttackSpeed = character.ReturnCharacterAttackSpeed();
         float timeCount = (float)(200 / getAttackSpeed);
@@ -413,7 +451,7 @@ public class ItemManager : MonoBehaviour
         }
     }
 
-    IEnumerator BoosterCoroutine()
+    IEnumerator BoosterCoroutine(int getRank)
     {
         double getBasicSpeed = character.ReturnCharacterMoveSpeed();
         double getAttackSpeed = character.ReturnCharacterAttackSpeed();
@@ -434,13 +472,13 @@ public class ItemManager : MonoBehaviour
         }
     }
 
-    void BioSnach()
+    void BioSnach(int getRank)
     {
         float getAbsorbAttackData = 100;
         character.SetAbsorbAttackData(getAbsorbAttackData);
     }
     
-    void InterceptDroneCoroutine()
+    void InterceptDroneCoroutine(int getRank)
     {
         GameObject interceptDroneParent = Instantiate(itemPrefabArr[15]);
         interceptDroneParent.transform.SetParent(character.transform);

--- a/Assets/Scenes/Night/Script/Manager/NightManager.cs
+++ b/Assets/Scenes/Night/Script/Manager/NightManager.cs
@@ -56,8 +56,8 @@ public class NightManager : MonoBehaviour
         SetEnemyArrData();
 
         //몬스터 생성 함수
-        InstantiateEnemy();
-        //TestEnemy(); TestEnemy();
+        //InstantiateEnemy();
+        TestEnemy();
     }
 
     void SetEnemyArrData()
@@ -100,7 +100,7 @@ public class NightManager : MonoBehaviour
     void TestEnemy()
     {
         eliteEnemyArr[1].SetEnforceData(nowLevel, true);
-        GameObject eliteEnemyClone = Instantiate(eliteEnemyPrefabArr[1], SetEnemyPos(), Quaternion.identity);
+        GameObject eliteEnemyClone = Instantiate(normalEnemyPrefabArr[0], SetEnemyPos(), Quaternion.identity);
         eliteEnemyClone.transform.SetParent(enemyCloneParent);
         eliteEnemyClone.SetActive(true);
     }

--- a/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF.asset
+++ b/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF.asset
@@ -37,7 +37,7 @@ Material:
     - _PerspectiveFilter: 0.875
     - _ScaleRatioA: 0.9
     - _ScaleRatioB: 1
-    - _ScaleRatioC: 0.65925
+    - _ScaleRatioC: 0.65924996
     - _ScaleX: 1
     - _ScaleY: 1
     - _ShaderFlags: 0


### PR DESCRIPTION
## 작업 목록

1. 여러 아이템과 특성 동시에 작동되는 것 확인

## 자잘한 수정 사항들

1. 캐릭터 데이터를 게임 매니저의 player에서 가져오도록 수정 1. 플레이어 데이터에 장비, 특성, 아이템, 암살 데이터 넣음 2. 플레이어 데이터에 startMoney, earnMoney, shopSlot, itemSlot, shopMinRank, shopMaxRank, dropRank, dropRate 추가 3. 엑셀에서 변경된 데이터 이름들 적용

5. 아이템 매니저에서 선택한 아이템을 게임 매니저 플레이어에서 가져오도록 수정 1. 센트리 볼, 차징 리퍼, 재앙 드론, 멀티 슬래셔 작업 완료

수정한 부분 중 내 파트 아닌 것

1. DataManager.itemList 에서 item이 [serializable]이 아닌 [serializeFiled]로 되어 있어 올바르게 json 파일을 받아오지 못하는 경우 수정