### PR TITLE
230806/정윤석/ 아이템 데이터 적용 완료 및 특성 저장 방식 수정

### DIFF
--- a/Assets/Data/Json/Item.json
+++ b/Assets/Data/Json/Item.json
@@ -75,10 +75,10 @@
             "category": 0,
             "attackPowerCalc": 1,
             "attackPowerValue": 0.40,
-            "attackSpeedCalc": 0,
-            "attackSpeedValue": 0.00,
-            "attackRangeCalc": 1,
-            "attackRangeValue": 0.10
+            "attackSpeedCalc": 1,
+            "attackSpeedValue": 0.10,
+            "attackRangeCalc": 0,
+            "attackRangeValue": 0.00
         },
         {
             "itemIdx": 6,
@@ -155,10 +155,10 @@
             "category": 1,
             "attackPowerCalc": 1,
             "attackPowerValue": 0.10,
-            "attackSpeedCalc": 1,
-            "attackSpeedValue": 0.10,
-            "attackRangeCalc": 0,
-            "attackRangeValue": 0.00
+            "attackSpeedCalc": 0,
+            "attackSpeedValue": 0.00,
+            "attackRangeCalc": 1,
+            "attackRangeValue": 0.10
         },
         {
             "itemIdx": 11,
@@ -206,7 +206,7 @@
             "attackSpeedCalc": 1,
             "attackSpeedValue": 0.10,
             "attackRangeCalc": 1,
-            "attackRangeValue": -0.10
+            "attackRangeValue": 0.10
         },
         {
             "itemIdx": 14,
@@ -236,9 +236,9 @@
             "attackPowerCalc": 0,
             "attackPowerValue": 0.00,
             "attackSpeedCalc": 1,
-            "attackSpeedValue": 0.40,
+            "attackSpeedValue": 0.10,
             "attackRangeCalc": 1,
-            "attackRangeValue": -0.10
+            "attackRangeValue": 0.40
         },
         {
             "itemIdx": 16,
@@ -315,10 +315,10 @@
             "category": 0,
             "attackPowerCalc": 1,
             "attackPowerValue": 0.50,
-            "attackSpeedCalc": 0,
-            "attackSpeedValue": 0.00,
-            "attackRangeCalc": 1,
-            "attackRangeValue": 0.13
+            "attackSpeedCalc": 1,
+            "attackSpeedValue": 0.13,
+            "attackRangeCalc": 0,
+            "attackRangeValue": 0.00
         },
         {
             "itemIdx": 21,
@@ -395,10 +395,10 @@
             "category": 1,
             "attackPowerCalc": 1,
             "attackPowerValue": 0.15,
-            "attackSpeedCalc": 1,
-            "attackSpeedValue": 0.15,
+            "attackSpeedCalc": 0,
+            "attackSpeedValue": 0.00,
             "attackRangeCalc": 0,
-            "attackRangeValue": 0.00
+            "attackRangeValue": 0.15
         },
         {
             "itemIdx": 26,
@@ -446,7 +446,7 @@
             "attackSpeedCalc": 1,
             "attackSpeedValue": 0.15,
             "attackRangeCalc": 1,
-            "attackRangeValue": -0.13
+            "attackRangeValue": 0.13
         },
         {
             "itemIdx": 29,
@@ -476,9 +476,9 @@
             "attackPowerCalc": 0,
             "attackPowerValue": 0.00,
             "attackSpeedCalc": 1,
-            "attackSpeedValue": 0.55,
+            "attackSpeedValue": 0.13,
             "attackRangeCalc": 1,
-            "attackRangeValue": -0.13
+            "attackRangeValue": 0.55
         },
         {
             "itemIdx": 31,
@@ -555,10 +555,10 @@
             "category": 0,
             "attackPowerCalc": 1,
             "attackPowerValue": 0.70,
-            "attackSpeedCalc": 0,
-            "attackSpeedValue": 0.00,
-            "attackRangeCalc": 1,
-            "attackRangeValue": 0.17
+            "attackSpeedCalc": 1,
+            "attackSpeedValue": 0.17,
+            "attackRangeCalc": 0,
+            "attackRangeValue": 0.00
         },
         {
             "itemIdx": 36,
@@ -635,10 +635,10 @@
             "category": 1,
             "attackPowerCalc": 1,
             "attackPowerValue": 0.22,
-            "attackSpeedCalc": 1,
-            "attackSpeedValue": 0.20,
-            "attackRangeCalc": 0,
-            "attackRangeValue": 0.00
+            "attackSpeedCalc": 0,
+            "attackSpeedValue": 0.00,
+            "attackRangeCalc": 1,
+            "attackRangeValue": 0.20
         },
         {
             "itemIdx": 41,
@@ -686,7 +686,7 @@
             "attackSpeedCalc": 1,
             "attackSpeedValue": 0.20,
             "attackRangeCalc": 1,
-            "attackRangeValue": -0.17
+            "attackRangeValue": 0.17
         },
         {
             "itemIdx": 44,
@@ -716,9 +716,9 @@
             "attackPowerCalc": 0,
             "attackPowerValue": 0.00,
             "attackSpeedCalc": 1,
-            "attackSpeedValue": 0.75,
+            "attackSpeedValue": 0.17,
             "attackRangeCalc": 1,
-            "attackRangeValue": -0.17
+            "attackRangeValue": 0.75
         },
         {
             "itemIdx": 46,
@@ -795,10 +795,10 @@
             "category": 0,
             "attackPowerCalc": 1,
             "attackPowerValue": 0.95,
-            "attackSpeedCalc": 0,
-            "attackSpeedValue": 0.00,
-            "attackRangeCalc": 1,
-            "attackRangeValue": 0.22
+            "attackSpeedCalc": 1,
+            "attackSpeedValue": 0.22,
+            "attackRangeCalc": 0,
+            "attackRangeValue": 0.00
         },
         {
             "itemIdx": 51,
@@ -875,10 +875,10 @@
             "category": 1,
             "attackPowerCalc": 1,
             "attackPowerValue": 0.30,
-            "attackSpeedCalc": 1,
-            "attackSpeedValue": 0.30,
-            "attackRangeCalc": 0,
-            "attackRangeValue": 0.00
+            "attackSpeedCalc": 0,
+            "attackSpeedValue": 0.00,
+            "attackRangeCalc": 1,
+            "attackRangeValue": 0.30
         },
         {
             "itemIdx": 56,
@@ -926,7 +926,7 @@
             "attackSpeedCalc": 1,
             "attackSpeedValue": 0.30,
             "attackRangeCalc": 1,
-            "attackRangeValue": -0.22
+            "attackRangeValue": 0.22
         },
         {
             "itemIdx": 59,
@@ -956,9 +956,9 @@
             "attackPowerCalc": 0,
             "attackPowerValue": 0.00,
             "attackSpeedCalc": 1,
-            "attackSpeedValue": 1.00,
+            "attackSpeedValue": 0.22,
             "attackRangeCalc": 1,
-            "attackRangeValue": -0.22
+            "attackRangeValue": 1.00
         }
     ]
 }

--- a/Assets/Scenes/Night/NightScene.unity
+++ b/Assets/Scenes/Night/NightScene.unity
@@ -787,7 +787,7 @@ MonoBehaviour:
   characterParent: {fileID: 182467907}
   character: {fileID: 889106807}
   hitBox: {fileID: 1410340655}
-  itemIdxArr: 040000000000000000000000
+  itemIdxArr: 0b0000000000000000000000
   itemRankArr: 000000000000000000000000
   tempItemIdx: 5
   itemPrefabArr:
@@ -3278,7 +3278,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2022676908
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3803,6 +3803,14 @@ PrefabInstance:
       propertyPath: shieldBarImage
       value: 
       objectReference: {fileID: 1406309405}
+    - target: {fileID: 3514429690322398353, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
+      propertyPath: hologramAnimatorArr.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3514429690322398353, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
+      propertyPath: hologramRendererArr.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 3514429690322398364, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
       propertyPath: m_IsTrigger
       value: 1

--- a/Assets/Scenes/Night/Prefabs/ItemPrefabs/HoligramTrick.prefab
+++ b/Assets/Scenes/Night/Prefabs/ItemPrefabs/HoligramTrick.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1930534812032361187}
   - component: {fileID: 1930534812032361184}
+  - component: {fileID: 8148442991805744504}
   m_Layer: 0
   m_Name: HoligramTrick
   m_TagString: Untagged
@@ -73,7 +74,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: f76b3fce4d1d69247a93ffcf03d21e25, type: 3}
+  m_Sprite: {fileID: 21300000, guid: c40f4d72385234ad392a57d46329227a, type: 3}
   m_Color: {r: 0.50980395, g: 0.8431373, b: 0.96470594, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -84,3 +85,24 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!95 &8148442991805744504
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1930534812032361185}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 289c3540b772349d5b4316186667a57a, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/Assets/Scenes/Night/Script/Class/Character.cs
+++ b/Assets/Scenes/Night/Script/Class/Character.cs
@@ -53,11 +53,14 @@ public class Character : MonoBehaviour
     //아이템 관련
     public bool isDoubleAttack = false;
     public bool isHologramTrickOn = false;
+    public bool isHologramAnimate = false;
     public bool isAntiPhenetOn = false;
     public bool isMoveBackOn = false;
 
     // 애니메이션
     private Animator animator;
+    public Animator[] hologramAnimatorArr;
+    public SpriteRenderer[] hologramRendererArr;
 
     private void Awake() {
         //characterData = new CharacterTrashData(isCheat);
@@ -158,6 +161,17 @@ public class Character : MonoBehaviour
         characterRigid.velocity = joystickDir.normalized * ConvertMoveSpeedToPixelSpeed(characterData.moveSpeed);
         animator.SetBool("move", true);
         characterSpriteRanderer.flipX = (nowDir.x < 0) ? false : true;
+
+        //홀로그램도 같이 움직이도록
+        if(isHologramAnimate)
+        {
+            for(int i =0; i<2; i++)
+            {
+                hologramAnimatorArr[i].SetBool("move", true);
+                hologramRendererArr[i].flipX = (nowDir.x < 0) ? false : true;
+            }
+        }
+
         //transform.localScale = (nowDir.x < 0) ? new Vector3(1, 1, 1) : new Vector3(-1, 1, 1);     아이템도 같이 이동해서 주석처리했어
     }
 
@@ -165,6 +179,15 @@ public class Character : MonoBehaviour
         nowDir = Vector3.zero;
         characterRigid.velocity = Vector3.zero;
         animator.SetBool("move", false);
+
+        //홀로그램도 같이 움직이도록
+        if (isHologramAnimate)
+        {
+            for (int i = 0; i < 2; i++)
+            {
+                hologramAnimatorArr[i].SetBool("move", false);
+            }
+        }
     }
 
     float ConvertMoveSpeedToPixelSpeed(double getMoveSpeed) {
@@ -189,6 +212,15 @@ public class Character : MonoBehaviour
             if (!isDoubleAttack) {
                 //공격 애니메이션 진행
                 animator.SetTrigger("attack");
+
+                //홀로그램도 같이 움직이도록
+                if (isHologramAnimate)
+                {
+                    for (int i = 0; i < 2; i++)
+                    {
+                        hologramAnimatorArr[i].SetTrigger("attack");
+                    }
+                }
 
                 hitBox.SetActive(true);
                 SetHitbox();
@@ -405,6 +437,16 @@ public class Character : MonoBehaviour
                 Debug.Log("GameEnd");
                 // TODO: 죽은 모션이 나온 후 결과 창이 뜨도록 딜레이 필요
                 animator.SetTrigger("die");
+
+                //홀로그램도 같이 움직이도록
+                if (isHologramAnimate)
+                {
+                    for (int i = 0; i < 2; i++)
+                    {
+                        hologramAnimatorArr[i].SetTrigger("die");
+                    }
+                }
+
                 characterData.curHp = 0;
                 hpBarImage.fillAmount = 0;
 
@@ -416,6 +458,16 @@ public class Character : MonoBehaviour
     //데미지를 받았을 경우 액션
     void SetDamagedAnim() {
         animator.SetTrigger("knockback");
+
+        //홀로그램도 같이 움직이도록
+        if (isHologramAnimate)
+        {
+            for (int i = 0; i < 2; i++)
+            {
+                hologramAnimatorArr[i].SetTrigger("knockback");
+            }
+        }
+
         StartCoroutine(SetDamagedAnimCoroutine());
     }
 
@@ -595,11 +647,17 @@ public class Character : MonoBehaviour
     }
 
     //데미지 경감용
+
+    public void SetAntiPhenetData(float getReductionRate)
+    {
+        characterData.damageReductionRate = getReductionRate;
+    }
+
     double AntiPhenetUse(double getAttackPowerData)
     {
         if(isAntiPhenetOn)
         {
-            return getAttackPowerData / characterData.attackPower;
+            return getAttackPowerData * (1 - characterData.damageReductionRate);
         }
         else
             return getAttackPowerData;

--- a/Assets/Scenes/Night/Script/Class/Item/GravityBind.cs
+++ b/Assets/Scenes/Night/Script/Class/Item/GravityBind.cs
@@ -8,13 +8,18 @@ public class GravityBind : MonoBehaviour
     public Character character;
     LayerMask enemyLayer;
     [SerializeField]
-    float detectRadius;
+    float detectScale;
     [SerializeField]
     double getEnemySpeed;
     [SerializeField]
     float spinSpeed;
 
+    [SerializeField]
+    float slowRate;
+
     EnemyParent getEnemyScript;
+
+    int itemRank;
 
     private void Start()
     {
@@ -24,6 +29,41 @@ public class GravityBind : MonoBehaviour
     private void Update()
     {
         this.transform.localPosition = character.transform.position;
+    }
+
+    public void SetItemRank(int getRank)
+    {
+        itemRank = getRank;
+        SetGravityBindData();
+    }
+
+    void SetGravityBindData()
+    {
+        float characterAttackSpeed = (float)character.ReturnCharacterAttackSpeed();
+        float characterAttackRange = (float)character.ReturnCharacterAttackRange();
+
+        switch (itemRank)
+        {
+            case 0:
+                detectScale = characterAttackRange * 0.15f * (float)DataManager.instance.itemList.item[10].attackRangeValue;
+                slowRate = characterAttackSpeed * (float)DataManager.instance.itemList.item[10].attackSpeedValue * 0.01f;
+                Debug.Log(slowRate);
+                break;
+            case 1:
+                detectScale = characterAttackRange * 0.15f * (float)DataManager.instance.itemList.item[25].attackRangeValue;
+                slowRate = characterAttackSpeed * (float)DataManager.instance.itemList.item[25].attackSpeedValue * 0.01f;
+                break;
+            case 2:
+                detectScale = characterAttackRange * 0.15f * (float)DataManager.instance.itemList.item[40].attackRangeValue;
+                slowRate = characterAttackSpeed * (float)DataManager.instance.itemList.item[40].attackSpeedValue * 0.01f;
+                break;
+            case 3:
+                detectScale = characterAttackRange * 0.15f * (float)DataManager.instance.itemList.item[55].attackRangeValue;
+                slowRate = characterAttackSpeed * (float)DataManager.instance.itemList.item[55].attackSpeedValue * 0.01f;
+                break;
+        }
+        detectScale /= 3;   //이미지 기본 픽셀이 300px라서 100px로 맞춰주고 스케일 조절하기 위해 넣었음.
+        this.transform.localScale = new Vector3(detectScale, detectScale, detectScale);
     }
 
     private void OnTriggerEnter2D(Collider2D getCol)
@@ -48,7 +88,7 @@ public class GravityBind : MonoBehaviour
         getEnemySpeed = getEnemyScript.ReturnEnemyMoveSpeed();
 
         getEnemyScript.isSlow = true;
-        getEnemyScript.SetEnemyMoveSpeed(getEnemySpeed * 0.5f);
+        getEnemyScript.SetEnemyMoveSpeed(getEnemySpeed * (1 - slowRate));
     }
 
     void ExitSlowEnemy(Collider2D getCol)
@@ -58,7 +98,7 @@ public class GravityBind : MonoBehaviour
         getEnemySpeed = getEnemyScript.ReturnEnemyMoveSpeed();
 
         getEnemyScript.isSlow = false;
-        getEnemyScript.SetEnemyMoveSpeed(getEnemySpeed * 2);
+        getEnemyScript.SetEnemyMoveSpeed(getEnemySpeed / (1 - slowRate));
     }
 
     IEnumerator SpinGravityBindCoroutine()

--- a/Assets/Scenes/Night/Script/Class/Item/InterceptDrone.cs
+++ b/Assets/Scenes/Night/Script/Class/Item/InterceptDrone.cs
@@ -23,9 +23,12 @@ public class InterceptDrone : MonoBehaviour
     float droneAngle;
     [SerializeField]
     float detectRadius;
+    float timeCount;
 
-    double getCharacterAttackSpeed;
-    double getCharacterAttackRange;
+    int itemRank;
+
+    float getCharacterAttackSpeed;
+    float getCharacterAttackRange;
 
     Projectile getProjScript;
 
@@ -33,6 +36,38 @@ public class InterceptDrone : MonoBehaviour
     {
         DetectProjectile();
         StartCoroutine(DroneRotate());
+    }
+    public void SetItemRank(int getRank)
+    {
+        itemRank = getRank;
+        SetInterceptDroneData();
+    }
+
+    void SetInterceptDroneData()
+    {
+        float characterAttackSpeed = (float)character.ReturnCharacterAttackSpeed();
+        float characterAttackRange = (float)character.ReturnCharacterAttackRange();
+
+        switch (itemRank)
+        {
+            case 0:
+                timeCount = 40 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[14].attackSpeedValue);
+                detectRadius = characterAttackRange * 0.15f * (float)DataManager.instance.itemList.item[14].attackRangeValue;
+                break;
+            case 1:
+                timeCount = 40 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[29].attackSpeedValue);
+                detectRadius = characterAttackRange * 0.15f * (float)DataManager.instance.itemList.item[29].attackRangeValue;
+                break;
+            case 2:
+                timeCount = 40 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[44].attackSpeedValue);
+                detectRadius = characterAttackRange * 0.15f * (float)DataManager.instance.itemList.item[44].attackRangeValue;
+                break;
+            case 3:
+                timeCount = 40 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[59].attackSpeedValue);
+                detectRadius = characterAttackRange * 0.15f * (float)DataManager.instance.itemList.item[59].attackRangeValue;
+                break;
+        }
+        Debug.Log(timeCount + "/ " + detectRadius);
     }
 
     IEnumerator DroneRotate()
@@ -56,7 +91,7 @@ public class InterceptDrone : MonoBehaviour
     //    centryBallImage.transform.rotation = Quaternion.AngleAxis(angle - 180, Vector3.forward);
     //}
 
-    public void SetInterceptDrone(double getAttackSpeed, double getAttackRange)
+    public void SetInterceptDrone(float getAttackSpeed, float getAttackRange)
     {
         getCharacterAttackRange = getAttackRange;
         getCharacterAttackSpeed = getAttackSpeed;
@@ -83,7 +118,7 @@ public class InterceptDrone : MonoBehaviour
                     InterceptProj(colArr[i]);
                 }
             }
-            yield return new WaitForSeconds(1f);
+            yield return new WaitForSeconds(timeCount);
         }
     }
 

--- a/Assets/Scenes/Night/Script/Class/Item/RailPiercer.cs
+++ b/Assets/Scenes/Night/Script/Class/Item/RailPiercer.cs
@@ -17,8 +17,8 @@ public class RailPiercer : MonoBehaviour
     [SerializeField]
     SpriteRenderer railPiercerImageRenderer;
     Rigidbody2D railPiercerRigid;
-    double attackPower = 500;
-    double attackSpeed;
+    [SerializeField] double attackPower = 500;
+    [SerializeField] double attackSpeed;
     float hitBoxScale;
     bool isWatchRight = true;
     bool isShoot = false;
@@ -36,29 +36,38 @@ public class RailPiercer : MonoBehaviour
     public void SetItemRank(int getRank)
     {
         itemRank = getRank;
+        SetRailPiercerData();
     }
 
-    void SetChargingReaperData()
+    void SetRailPiercerData()
     {
+        float characterAttackSpeed = (float)character.ReturnCharacterAttackSpeed();
+        float characterAttackPower = (float)character.ReturnCharacterAttackPower();
+
         switch (itemRank)
         {
             case 0:
+                attackPower = characterAttackPower * DataManager.instance.itemList.item[4].attackPowerValue;
+                attackSpeed = 10 / (characterAttackSpeed * DataManager.instance.itemList.item[4].attackSpeedValue);
                 break;
             case 1:
+                attackPower = characterAttackPower * DataManager.instance.itemList.item[19].attackPowerValue;
+                attackSpeed = 10 / (characterAttackSpeed * DataManager.instance.itemList.item[19].attackSpeedValue);
                 break;
             case 2:
+                attackPower = characterAttackPower * DataManager.instance.itemList.item[34].attackPowerValue;
+                attackSpeed = 10 / (characterAttackSpeed * DataManager.instance.itemList.item[34].attackSpeedValue);
                 break;
             case 3:
+                attackPower = characterAttackPower * DataManager.instance.itemList.item[49].attackPowerValue;
+                attackSpeed = 10 / (characterAttackSpeed * DataManager.instance.itemList.item[49].attackSpeedValue);
                 break;
         }
     }
 
-    public void ShootRailPiercer(double getAttackSpeed, double getAttackDamage)
+    public void ShootRailPiercer()
     {
         railPiercerHitBox.SetActive(false);
-
-        attackSpeed = getAttackSpeed;
-        attackPower = getAttackDamage;
 
         //우측을 바라보면 우측으로 길이가 길어짐
         if (isWatchRight)
@@ -100,7 +109,7 @@ public class RailPiercer : MonoBehaviour
             railPiercerHitBox.SetActive(false);
             isShoot = false;
 
-            yield return new WaitForSeconds((float)attackSpeed / 10);
+            yield return new WaitForSeconds((float)attackSpeed);
         }
     }
 

--- a/Assets/Scenes/Night/Script/Manager/ItemManager.cs
+++ b/Assets/Scenes/Night/Script/Manager/ItemManager.cs
@@ -316,11 +316,8 @@ public class ItemManager : MonoBehaviour
         railPiercerScript.nightManager = nightManager;
         railPiercerScript.SetItemRank(getRank);
 
-        double characterAttackSpeed = character.ReturnCharacterAttackSpeed();
-        double characterAttackPower = character.ReturnCharacterAttackPower();
-
         railPiercerScript.SetRailPiercerPos();
-        railPiercerScript.ShootRailPiercer(characterAttackSpeed, characterAttackPower);
+        railPiercerScript.ShootRailPiercer();
     }
 
     IEnumerator FirstAdeCoroutine(int getRank)
@@ -332,9 +329,31 @@ public class ItemManager : MonoBehaviour
 
         double nowHp = character.ReturnCharacterHitPoint();
         double firstAdeHp = character.ReturnCharacterHitPointMax() * 0.4f;
-        double healHp = character.ReturnCharacterAttackPower();
+        float healHp = (float)character.ReturnCharacterAttackPower();
+        int coolTime = 30;
 
-        while(!nightManager.isStageEnd)
+
+        switch (getRank)
+        {
+            case 0:
+                healHp *= (float)DataManager.instance.itemList.item[5].attackPowerValue;
+                coolTime = 30;
+                break;
+            case 1:
+                healHp *= (float)DataManager.instance.itemList.item[20].attackPowerValue;
+                coolTime = 25;
+                break;
+            case 2:
+                healHp *= (float)DataManager.instance.itemList.item[35].attackPowerValue;
+                coolTime = 20;
+                break;
+            case 3:
+                healHp *= (float)DataManager.instance.itemList.item[50].attackPowerValue;
+                coolTime = 15;
+                break;
+        }
+
+        while (!nightManager.isStageEnd)
         {
             while (nowHp >= firstAdeHp)
             {
@@ -344,7 +363,7 @@ public class ItemManager : MonoBehaviour
 
             character.HealHp(healHp, firstAdeParent);
 
-            yield return new WaitForSeconds(20);
+            yield return new WaitForSeconds(coolTime);
         }
     }
 
@@ -355,11 +374,32 @@ public class ItemManager : MonoBehaviour
         barriorParent.transform.position = character.transform.position;
         Barrior barriorScript = barriorParent.GetComponent<Barrior>();
 
-        double characterAttackSpeed = character.ReturnCharacterAttackSpeed();
-        double characterAttackPower = character.ReturnCharacterAttackPower();
-        float shieldPoint = (float)characterAttackPower;
+        float characterAttackSpeed = (float)character.ReturnCharacterAttackSpeed();
+        float characterAttackPower = (float)character.ReturnCharacterAttackPower();
+        float shieldPoint = characterAttackPower;
 
         double timeCount = 50 / characterAttackSpeed;
+
+        switch(getRank)
+        {
+            case 0:
+                shieldPoint *= (float)DataManager.instance.itemList.item[6].attackPowerValue;
+                timeCount = 90 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[6].attackSpeedValue);
+                break;
+            case 1:
+                shieldPoint *= (float)DataManager.instance.itemList.item[6].attackPowerValue;
+                timeCount = 90 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[21].attackSpeedValue);
+                break;
+            case 2:
+                shieldPoint *= (float)DataManager.instance.itemList.item[6].attackPowerValue;
+                timeCount = 90 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[36].attackSpeedValue);
+                break;
+            case 3:
+                shieldPoint *= (float)DataManager.instance.itemList.item[6].attackPowerValue;
+                timeCount = 90 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[51].attackSpeedValue);
+                break;
+        }
+
         while (!nightManager.isStageEnd)
         {
             character.SetShieldPointData(shieldPoint);
@@ -376,6 +416,7 @@ public class ItemManager : MonoBehaviour
     {
         GameObject[] hologramParentArr = new GameObject[2];
         Vector3 hologramVector;
+        character.isHologramAnimate = true;
 
         for (int i = 0; i < 2; i++)
         {
@@ -395,36 +436,94 @@ public class ItemManager : MonoBehaviour
             }
 
             hologramParentArr[i].transform.position = hologramVector;
+            character.hologramAnimatorArr[i] = hologramParent.GetComponent<Animator>();
+            character.hologramRendererArr[i] = hologramParent.GetComponent<SpriteRenderer>();
         }
 
-        double characterAttackSpeed = character.ReturnCharacterAttackSpeed();
-        double characterAttackRange = character.ReturnCharacterAttackRange();
+        float characterAttackSpeed = (float)character.ReturnCharacterAttackSpeed();
+        float characterAttackRange = (float)character.ReturnCharacterAttackRange();
 
-        double duration = characterAttackRange;
-        double timeCount = 1200 / characterAttackSpeed;
+        float duration = characterAttackRange;
+        float timeCount = 1200 / characterAttackSpeed;
 
-        while(!nightManager.isStageEnd)
+        switch (getRank)
+        {
+            case 0:
+                timeCount = 120 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[7].attackSpeedValue);
+                duration = characterAttackRange * (float)DataManager.instance.itemList.item[7].attackRangeValue;
+                break;
+            case 1:
+                timeCount = 120 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[22].attackSpeedValue);
+                duration = characterAttackRange * (float)DataManager.instance.itemList.item[22].attackRangeValue;
+                break;
+            case 2:
+                timeCount = 120 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[37].attackSpeedValue);
+                duration = characterAttackRange * (float)DataManager.instance.itemList.item[37].attackRangeValue;
+                break;
+            case 3:
+                timeCount = 120 / (characterAttackSpeed * (float)DataManager.instance.itemList.item[52].attackSpeedValue);
+                duration = characterAttackRange * (float)DataManager.instance.itemList.item[52].attackRangeValue;
+                break;
+        }
+
+        while (!nightManager.isStageEnd)
         {
             character.isHologramTrickOn = true;
-            yield return new WaitForSeconds((float)duration);
+            yield return new WaitForSeconds(duration);
             character.isHologramTrickOn = false;
             
-            yield return new WaitForSeconds((float)timeCount);
+            yield return new WaitForSeconds(timeCount);
         }
+
+        character.isHologramAnimate = false;
     }
 
     void AntiPhenet(int getRank)
     {
         character.isAntiPhenetOn = true;
+
+        switch(getRank)
+        {
+            case 0:
+                character.SetAntiPhenetData((float)DataManager.instance.itemList.item[8].attackPowerValue);
+                break;
+            case 1:
+                character.SetAntiPhenetData((float)DataManager.instance.itemList.item[23].attackPowerValue);
+                break;
+            case 2:
+                character.SetAntiPhenetData((float)DataManager.instance.itemList.item[38].attackPowerValue);
+                break;
+            case 3:
+                character.SetAntiPhenetData((float)DataManager.instance.itemList.item[53].attackPowerValue);
+                break;
+        }
     }
 
     void RegenerationArmor(int getRank)
     {
-        double addHp = character.ReturnCharacterAttackPower();
-        double addHpRegen = character.ReturnCharacterAttackRange();
+        float addHp = (float)character.ReturnCharacterAttackPower();
+        float addHpRegen = (float)character.ReturnCharacterAttackRange();
 
-        //임시 코드
-        addHpRegen = 100;
+        switch (getRank)
+        {
+            case 0:
+                addHp *= (float)DataManager.instance.itemList.item[9].attackPowerValue;
+                addHpRegen *= (float)DataManager.instance.itemList.item[9].attackRangeValue;
+                Debug.Log(addHpRegen);
+                break;
+            case 1:
+                addHp *= (float)DataManager.instance.itemList.item[24].attackPowerValue;
+                addHpRegen *= (float)DataManager.instance.itemList.item[24].attackRangeValue;
+                break;
+            case 2:
+                addHp *= (float)DataManager.instance.itemList.item[39].attackPowerValue;
+                addHpRegen *= (float)DataManager.instance.itemList.item[39].attackRangeValue;
+                break;
+            case 3:
+                addHp *= (float)DataManager.instance.itemList.item[54].attackPowerValue;
+                addHpRegen *= (float)DataManager.instance.itemList.item[54].attackRangeValue;
+                break;
+        }
 
         character.SetCharacterHitPointMax(addHp);
         character.SetCharacterHpRegen(addHpRegen);
@@ -437,32 +536,73 @@ public class ItemManager : MonoBehaviour
         gravityBindParent.transform.localPosition = character.transform.position;
         gravityBindParent.transform.GetChild(0).GetComponent<GravityBind>().character = character;
         gravityBindParent.transform.GetChild(0).GetComponent<GravityBind>().nightManager = nightManager;
+        gravityBindParent.transform.GetChild(0).GetComponent<GravityBind>().SetItemRank(getRank);
     }
 
     IEnumerator MoveBack(int getRank)
     {
-        double getAttackSpeed = character.ReturnCharacterAttackSpeed();
-        float timeCount = (float)(200 / getAttackSpeed);
+        float getAttackSpeed = (float)character.ReturnCharacterAttackSpeed();
+        float timeCount = 200 / getAttackSpeed;
 
-        while(!nightManager.isStageEnd)
+        switch (getRank)
+        {
+            case 0:
+                timeCount = 20 / (getAttackSpeed * (float)DataManager.instance.itemList.item[11].attackSpeedValue);
+                break;
+            case 1:
+                timeCount = 20 / (getAttackSpeed * (float)DataManager.instance.itemList.item[26].attackSpeedValue);
+                break;
+            case 2:
+                timeCount = 20 / (getAttackSpeed * (float)DataManager.instance.itemList.item[41].attackSpeedValue);
+                break;
+            case 3:
+                timeCount = 20 / (getAttackSpeed * (float)DataManager.instance.itemList.item[56].attackSpeedValue);
+                break;
+        }
+        
+        while (!nightManager.isStageEnd)
         {
             character.isMoveBackOn = true;
-            yield return new WaitForSeconds(1);
+            yield return new WaitForSeconds(timeCount);
         }
     }
 
     IEnumerator BoosterCoroutine(int getRank)
     {
-        double getBasicSpeed = character.ReturnCharacterMoveSpeed();
-        double getAttackSpeed = character.ReturnCharacterAttackSpeed();
-        double getAttackRange = character.ReturnCharacterAttackRange();
-        double getAttackPower = character.ReturnCharacterAttackPower();
+        float getBasicSpeed = (float)character.ReturnCharacterMoveSpeed();
+        float getAttackSpeed = (float)character.ReturnCharacterAttackSpeed();
+        float getAttackRange = (float)character.ReturnCharacterAttackRange();
+        float getAttackPower = (float)character.ReturnCharacterAttackPower();
 
-        float timeCount = (float)(300 / getAttackSpeed); Debug.Log(timeCount);
-        float duration = (float)getAttackRange;
-        double speed = getAttackPower; 
-
-        while(!nightManager.isStageEnd)
+        float timeCount = 300 / getAttackSpeed;
+        float duration = getAttackRange;
+        double speed = getAttackPower;
+        
+        switch (getRank)
+        {
+            case 0:
+                timeCount = 30 / (getAttackSpeed * (float)DataManager.instance.itemList.item[12].attackSpeedValue);
+                duration = getAttackRange * (float)DataManager.instance.itemList.item[12].attackRangeValue;
+                speed = getBasicSpeed + getAttackPower * (float)DataManager.instance.itemList.item[12].attackPowerValue;
+                break;
+            case 1:
+                timeCount = 20 / (getAttackSpeed * (float)DataManager.instance.itemList.item[27].attackSpeedValue);
+                duration = getAttackRange * (float)DataManager.instance.itemList.item[27].attackRangeValue;
+                speed = getBasicSpeed + getAttackPower * (float)DataManager.instance.itemList.item[27].attackPowerValue;
+                break;
+            case 2:
+                timeCount = 20 / (getAttackSpeed * (float)DataManager.instance.itemList.item[42].attackSpeedValue);
+                duration = getAttackRange * (float)DataManager.instance.itemList.item[42].attackRangeValue;
+                speed = getBasicSpeed + getAttackPower * (float)DataManager.instance.itemList.item[42].attackPowerValue;
+                break;
+            case 3:
+                timeCount = 20 / (getAttackSpeed * (float)DataManager.instance.itemList.item[57].attackSpeedValue);
+                duration = getAttackRange * (float)DataManager.instance.itemList.item[57].attackRangeValue;
+                speed = getBasicSpeed + getAttackPower * (float)DataManager.instance.itemList.item[57].attackPowerValue;
+                break;
+        }
+        
+        while (!nightManager.isStageEnd)
         {
             character.SetMoveSpeed(speed);
             yield return new WaitForSeconds(duration);
@@ -474,7 +614,23 @@ public class ItemManager : MonoBehaviour
 
     void BioSnach(int getRank)
     {
-        float getAbsorbAttackData = 100;
+        float getAbsorbAttackData = 1;
+
+        switch (getRank)
+        {
+            case 0:
+                getAbsorbAttackData = 1;
+                break;
+            case 1:
+                getAbsorbAttackData = 2;
+                break;
+            case 2:
+                getAbsorbAttackData = 3;
+                break;
+            case 3:
+                getAbsorbAttackData = 5;
+                break;
+        }
         character.SetAbsorbAttackData(getAbsorbAttackData);
     }
     
@@ -485,9 +641,10 @@ public class ItemManager : MonoBehaviour
         interceptDroneParent.transform.localPosition = character.transform.position;
         interceptDroneParent.GetComponent<InterceptDrone>().character = character;
         interceptDroneParent.GetComponent<InterceptDrone>().nightManager = nightManager;
+        interceptDroneParent.GetComponent<InterceptDrone>().SetItemRank(getRank);
 
-        double getAttackSpeed = character.ReturnCharacterAttackSpeed();
-        double getAttackRange = character.ReturnCharacterAttackRange();
+        float getAttackSpeed = (float)character.ReturnCharacterAttackSpeed();
+        float getAttackRange = (float)character.ReturnCharacterAttackRange();
 
         interceptDroneParent.GetComponent<InterceptDrone>().SetInterceptDrone(getAttackRange, getAttackSpeed);
     }

--- a/Assets/Scenes/Night/Script/Manager/TraitManager.cs
+++ b/Assets/Scenes/Night/Script/Manager/TraitManager.cs
@@ -27,11 +27,14 @@ public class TraitManager : MonoBehaviour
     [SerializeField]
     List<int> traitIndexList;
     [SerializeField]
+    List<int> traitTestIndexList;
+    [SerializeField]
     List<TraitTrash> traitOldList;
+    [SerializeField]
+    List<Trait> traitTestList;
 
     //최종 데이터매니저에서 가져오는 데이터들
     List<Trait> traitList;
-    Trait nowTrait;
 
     [SerializeField]
     int testTraitIndex;
@@ -46,84 +49,113 @@ public class TraitManager : MonoBehaviour
         //TestActiveTrait(testTraitIndex);
         //SetTrait2();
 
+        //테스트용 코드(230806)
+        //그냥 플레이어 데이터 삽입되면 주석처리하고 아래 코드 실행하면 됩니다.
+        FindActiveTraitTest();
+        SetTestTrait();
 
         //실제로 구동되는 코드 입니다. 
+        //FindActiveTrait();
+        //SetTrait();
 
+    }
+
+    void FindActiveTraitTest()
+    {
+        //index = 28, 42, 43, 44, 45, 61, 62 총 7개의 액티브가 존재.
+        for (int i = 0; i < traitTestIndexList.Count; i++)
+        {
+            traitTestList.Add(DataManager.instance.traitList.trait[traitTestIndexList[i]]);
+        }
     }
 
     //게임매니저에서 저장된 플레이어 데이터를 가져와 특성을 저장합니다.
-    void SetTraitList()
+    void FindActiveTrait()
     {
-        //플레이어 데이터에서 있는 인덱스 traitIndexList에 옮김
-        //traitList에 또 넣음
-    }
+        int[] idxArr = { 28, 42, 43, 44, 45, 61, 62 };
 
-    //임시로 각 레벨당 첫번째 특성을 가지도록 설정(만렙기준)
-    void SetTraitIndexListTemp()
-    {
-        int nowLevel = 1;
-        for (int i = 0; i < traitTrashWrapper.traitTrashArr.Length; i++)
+        //index = 28, 42, 43, 44, 45, 61, 62 총 7개의 액티브가 존재.
+        for(int i =0; i < idxArr.Length; i++)
         {
-            if (traitTrashWrapper.traitTrashArr[i].traitReqLvl == nowLevel)
+            if (GameManager.instance.player.trait[idxArr[i]])
             {
-                nowLevel++;
-                traitIndexList.Add(traitTrashWrapper.traitTrashArr[i].traitIdx);
-                traitOldList.Add(traitTrashWrapper.traitTrashArr[i]);
+                traitIndexList[i] = idxArr[i];
+                traitList.Add(DataManager.instance.traitList.trait[idxArr[i] - 1]);
             }
         }
     }
 
+    //삭제된 코드
+    //임시로 각 레벨당 첫번째 특성을 가지도록 설정(만렙기준)
+    //void SetTraitIndexListTemp()
+    //{
+    //    int nowLevel = 1;
+    //    for (int i = 0; i < traitTrashWrapper.traitTrashArr.Length; i++)
+    //    {
+    //        if (traitTrashWrapper.traitTrashArr[i].traitReqLvl == nowLevel)
+    //        {
+    //            nowLevel++;
+    //            traitIndexList.Add(traitTrashWrapper.traitTrashArr[i].traitIdx);
+    //            traitOldList.Add(traitTrashWrapper.traitTrashArr[i]);
+    //        }
+    //    }
+    //}
+
     //특성을 테스트하기 위해서 만들어둔 함수
-    void TestActiveTrait(int testIndex)
-    {
-        traitOldList.Add(traitTrashWrapper.traitTrashArr[testIndex]);
-    }
+    //void TestActiveTrait(int testIndex)
+    //{
+    //    traitOldList.Add(traitTrashWrapper.traitTrashArr[testIndex]);
+    //}
 
     //선택한 특성을 실행하는 함수
+
+    void SetTestTrait()
+    {
+        Trait nowTrait;
+        for (int i = 0; i < traitTestList.Count; i++)
+        {
+            nowTrait = traitTestList[i];
+            SetActiveTrait(nowTrait);
+        }
+    }
+
     void SetTrait()
     {
         Trait nowTrait;
-        for (int i = 0; i < traitOldList.Count; i++)
+        for (int i = 0; i < traitList.Count; i++)
         {
             nowTrait = traitList[i];
-            //패시브 특성 설정
-            if (traitOldList[i].effectType1 != EffectType.active)
-            {
-                //SetPassiveTrait(nowTrait);
-                //패시브 특성은 밤 씬으로 들어오기 이전에 적용되어 있을 예정
-            }
-
-            //액티브 특성 설정
-            else
-            {
-                //SetActiveTrait(nowTrait);
-            }
-        }
-    }
-
-    //선택한 특성을 실행하는 함수(이젠 안씀)
-    void SetOldTrait()
-    {
-        TraitTrash nowTrait;
-        for(int i =0; i< traitOldList.Count; i++)
-        {
-            nowTrait = traitOldList[i];
-            //패시브 특성 설정
-            if (traitOldList[i].effectType1 != EffectType.active)
-            {
-                //SetPassiveTrait(nowTrait);
-                //패시브 특성은 밤 씬으로 들어오기 이전에 적용되어 있을 예정
-            }
-
-            //액티브 특성 설정
-            else
+            //액티브 특성 실행
+            if (traitOldList[i].effectType1 == EffectType.active)
             {
                 SetActiveTrait(nowTrait);
             }
         }
     }
 
-    //각 특성에서 변화하는 값들을 대입하는 함수
+    //선택한 특성을 실행하는 함수(이젠 안씀)
+    //void SetOldTrait()
+    //{
+    //    TraitTrash nowTrait;
+    //    for(int i =0; i< traitOldList.Count; i++)
+    //    {
+    //        nowTrait = traitOldList[i];
+    //        //패시브 특성 설정
+    //        if (traitOldList[i].effectType1 != EffectType.active)
+    //        {
+    //            //SetPassiveTrait(nowTrait);
+    //            //패시브 특성은 밤 씬으로 들어오기 이전에 적용되어 있을 예정
+    //        }
+
+    //        //액티브 특성 설정
+    //        else
+    //        {
+    //            SetActiveTrait(nowTrait);
+    //        }
+    //    }
+    //}
+
+    //각 특성에서 변화하는 값들을 대입하는 함수(낮씬에서 이미 데이터 정리되어 들어와 이제 필요 없음)
     void SetPassiveTrait(TraitTrash getTrait)
     {
         SetPassiveCharacterData(getTrait.effectType1, getTrait.traitEffectValue1, getTrait.traitEffectMulti1);
@@ -137,15 +169,16 @@ public class TraitManager : MonoBehaviour
         character.SetCharacterTrashData(getEffectType, getEffectValue, getEffectMulti);
     }
 
-    void SetActiveTrait(TraitTrash getTrait)
+    void SetActiveTrait(Trait getTrait)
     {
         //index = 28, 42, 43, 44, 45, 61, 62 총 7개의 액티브가 존재.
         ActiveTrait nowActive;
-        nowActive = (ActiveTrait)getTrait.traitIdx;
+        nowActive = (ActiveTrait)getTrait.index;
+        Debug.Log("액티브: " +nowActive);
         StartActive(nowActive, getTrait);
     }
 
-    void StartActive(ActiveTrait getActiveTrait, TraitTrash getTrait)
+    void StartActive(ActiveTrait getActiveTrait, Trait getTrait)
     {
         switch (getActiveTrait)
         {
@@ -176,20 +209,20 @@ public class TraitManager : MonoBehaviour
     }
 
     //특성 인덱스 28번 게임 시작시 쉴드 생성 코드
-    void SetStartShield(TraitTrash getTrait)
+    void SetStartShield(Trait getTrait)
     {
-        character.SetStartShieldPointData(getTrait.traitEffectValue1);
+        character.SetStartShieldPointData(getTrait.effectValue1);
     }
 
     //특성 인덱스 42번 n초마다 주변 적 끌어당기기 코드
-    IEnumerator DragEnemyCoroutine(TraitTrash getTrait)
+    IEnumerator DragEnemyCoroutine(Trait getTrait)
     {
         while (!nightManager.isStageEnd)
         {
-            yield return new WaitForSeconds(getTrait.traitEffectValue1);    //n초의 대기시간을 갖는 코드
+            yield return new WaitForSeconds(getTrait.effectValue1);    //n초의 대기시간을 갖는 코드
             Debug.Log("DrugEnemy");
             Collider2D[] getCols =
-                character.ReturnOverLapColliders(getTrait.traitEffectValue3 / 128, getTrait.traitEffectValue2 / 128);
+                character.ReturnOverLapColliders(getTrait.effectValue3 / 100, getTrait.effectValue2 / 100);
 
             if (getCols.Length != 0)
                 //이제 당겨
@@ -202,14 +235,14 @@ public class TraitManager : MonoBehaviour
     }
     public Collider2D[] arr;
     //특성 인덱스 43번 n초마다 주변 적 밀어내기 코드
-    IEnumerator ThrustEnemyCoroutine(TraitTrash getTrait)
+    IEnumerator ThrustEnemyCoroutine(Trait getTrait)
     {
         while (!nightManager.isStageEnd)
         {
-            yield return new WaitForSeconds(getTrait.traitEffectValue1);    //n초의 대기시간을 갖는 코드
+            yield return new WaitForSeconds(getTrait.effectValue1);    //n초의 대기시간을 갖는 코드
             Debug.Log("ThrustEnemy");
             Collider2D[] getCols =
-                character.ReturnOverLapColliders(getTrait.traitEffectValue2 / 128);
+                character.ReturnOverLapColliders(getTrait.effectValue2 / 100);
             arr = getCols;
             if (getCols != null)
                 //이제 당겨
@@ -224,15 +257,15 @@ public class TraitManager : MonoBehaviour
         }
     }
 
-    IEnumerator GetMoveSpeed(TraitTrash getTrait)
+    IEnumerator GetMoveSpeed(Trait getTrait)
     {
         Debug.Log("GetMoveSpeed");
         double defaultMoveSpeed = character.nowMoveSpeed;
-        double upgradeMoveSpeed = character.nowMoveSpeed * (1 + getTrait.traitEffectValue3);
+        double upgradeMoveSpeed = character.nowMoveSpeed * (1 + getTrait.effectValue3);
 
         //60~54초
         character.SetMoveSpeed(upgradeMoveSpeed);
-        while (timerManager.timerCount >= getTrait.traitEffectValue2)
+        while (timerManager.timerCount >= getTrait.effectValue2)
         {
             yield return new WaitForSeconds(0.5f);
         }
@@ -240,20 +273,20 @@ public class TraitManager : MonoBehaviour
         character.SetMoveSpeed(defaultMoveSpeed);
 
         //6~0초@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-        while (timerManager.timerCount >= getTrait.traitEffectValue1 * 5)
+        while (timerManager.timerCount >= getTrait.effectValue1)
         {
             yield return new WaitForSeconds(0.5f);
         }
         character.SetMoveSpeed(upgradeMoveSpeed);
     }
 
-    IEnumerator GetAttackPower(TraitTrash getTrait)
+    IEnumerator GetAttackPower(Trait getTrait)
     {
         Debug.Log("GetAttackPower");
         double hitPointMax = character.ReturnCharacterHitPointMax();
-        double hitPointGoal = hitPointMax * getTrait.traitEffectValue1;
+        double hitPointGoal = hitPointMax * getTrait.effectValue1;
         double attackPower = character.ReturnCharacterAttackPower();
-        attackPower *= (1 + getTrait.traitEffectValue2);
+        attackPower *= (1 + getTrait.effectValue2);
 
         while (character.ReturnCharacterHitPoint() >= hitPointGoal)
             yield return new WaitForSeconds(0.1f);
@@ -261,7 +294,7 @@ public class TraitManager : MonoBehaviour
         character.SetCharacterAttackPower(attackPower);
     }
 
-    IEnumerator StopEnemy(TraitTrash getTrait)
+    IEnumerator StopEnemy(Trait getTrait)
     {
         Debug.Log("StopEnemy");
 
@@ -279,7 +312,7 @@ public class TraitManager : MonoBehaviour
                 }
             }
 
-            yield return new WaitForSeconds(getTrait.traitEffectValue2);
+            yield return new WaitForSeconds(getTrait.effectValue2);
             Debug.Log("move");
             //적 오브젝트 정지
             for (int i = 0; i < enemyCloneParent.childCount; i++)
@@ -293,10 +326,10 @@ public class TraitManager : MonoBehaviour
         }
     }
 
-    void AbsorbDamage(TraitTrash getTrait)
+    void AbsorbDamage(Trait getTrait)
     {
         Debug.Log("AbsorbDamage");
-        character.SetAbsorbAttackData(getTrait.traitEffectValue2 * 200);
+        character.SetAbsorbAttackData(getTrait.effectValue2);
         character.canChange = true;
     }
 }


### PR DESCRIPTION
2. 아이템 홀로그램 트릭의 홀로그램이 캐릭터와 같이 움직이도록 설정
3. 문제점: 대체적으로 범위 관련 데이터들이 너무 좁음!(아래 영상 참조) 1. 랭크 0 그래비티 바인드 범위 ⇒ 공격범위(10) * 15(px값 변환) * 50% = 75px(범위 반지름) 2. 캐릭터 가로 390px

2. 특성 데이터들을 DataManager에서 끌어쓰도록 함수 변경
3. 선택한 특성 중 액티브 특성만 게임에서 적용되도록 함수 변경
4. 선택한 특성을 게임 매니저 플레이어에서 받도록 변경 1. → 현재 저장 데이터가 없어 testList를 만들어서 확인합니다.
5. 아이템 매니저에서 선택한 아이템을 게임 매니저 플레이어에서 가져오도록 수정 1. 230805 센트리 볼, 차징 리퍼, 재앙 드론, 멀티 슬래셔 작업 완료 2. 230806 아이템 전부 작업 완료
6. 아이템 랭크에 따라 다른 정보 값을 갖도록 함수 수정
7. 적의 데이터가 너무 높아지는 버그 수정(진행 중)

## 수정한 부분 중 내 파트 아닌 것

1. DataManager.itemList 에서 item이 [serializable]이 아닌 [serializeFiled]로 되어 있어 올바르게 json 파일을 받아오지 못하는 경우 수정

### Item.json 오류

1. JsonData 오류: 레일 피어서에서 attackSpeedValue의 값이 attackRangeValue로 잘못 표기되어서 수정
2. JsonData 오류: 재생성 갑옷에서 attackRangeValue의 값이 attackSpeedValue로 잘못 표기되어서 수정
3. JsonData 오류: 부스터에서 attackRangeValue의 값이 음수로 잘못 표기되어서 수정
4. JsonData 오류: 요격 드론에서 attackRangeValue의 값이 attackSpeed 값으로 잘못 표기되어 수정
5. JsonData 오류: 요격 드론에서 attackRangeValue의 값이 음수 값으로 잘못 표기되어 수정

### Trait.Json 오류

1. Trait의 effectValue1,2,3,4은 float로 해야합니다. 소수 있어요.
2. Trait의 effectMulti1,2,3,4은 effectValue1,2,3,4를 곱셉 하는지 확인하는 Bool값입니다. int로 하면 안되요