### PR TITLE
230826/정윤석/밤 오류 수정

### DIFF
--- a/Assets/Gamemanager/GameManager.cs
+++ b/Assets/Gamemanager/GameManager.cs
@@ -35,6 +35,7 @@ public class GameManager : MonoBehaviour
     public void InitPlayerData() {
         // init player
         this.player = new Player();
+        GameManager.instance.player.item.Add(DataManager.instance.itemList.item[6]);
 #if UNITY_EDITOR
         string initData = File.ReadAllText(Application.dataPath + "/Data/Json/InitPlayer.json");
         this.player = JsonUtility.FromJson<Player>(initData);

--- a/Assets/Scenes/Night/NightScene.unity
+++ b/Assets/Scenes/Night/NightScene.unity
@@ -5744,7 +5744,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 20
+  orthographic size: 30
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -6320,8 +6320,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.0018463, y: 0.0023499}
-  m_SizeDelta: {x: 800, y: 1780.7}
+  m_AnchoredPosition: {x: -0.0018463, y: -0.0090179}
+  m_SizeDelta: {x: 800, y: 1774.4}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1825701002
 MonoBehaviour:
@@ -6343,7 +6343,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 14f130306f7160c468e49fb76d3f471f, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 859346bcb7a2f184eb6234279f99947f, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -7555,8 +7555,16 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3514429690322398365, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
+      propertyPath: m_FlipX
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3514429690322398365, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
       propertyPath: m_FlipY
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3514429690322398367, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
+      propertyPath: m_Constraints
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3514429690357883042, guid: 090bbac8e3bc640e68f62f99fa9fd641, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Scenes/Night/Script/Class/Character.cs
+++ b/Assets/Scenes/Night/Script/Class/Character.cs
@@ -71,6 +71,7 @@ public class Character : MonoBehaviour
             characterData.curHp = characterData.maxHp;
         characterRigid = this.GetComponent<Rigidbody2D>();
         characterSpriteRanderer = GetComponent<SpriteRenderer>();
+        characterSpriteRanderer.flipX = false;
         animator = GetComponent<Animator>();
 
         //캐릭터의 스테이터스를 장비 등 변화에 따라 변화시킨다.

--- a/Assets/Scenes/Night/Script/Class/Enemy/EnemyParent.cs
+++ b/Assets/Scenes/Night/Script/Class/Enemy/EnemyParent.cs
@@ -74,6 +74,12 @@ public class EnemyParent : MonoBehaviour
 
             nowCharPos = character.transform.position;
             moveDir = nowCharPos - this.transform.position;
+
+            if (moveDir.x >= 0)
+                this.transform.localScale = new Vector3(-1, 1, 1);
+            else
+                this.transform.localScale = new Vector3(1, 1, 1);
+
             enemyRigid.velocity = moveDir.normalized * SetMoveSpeed(enemyData.moveSpeed);
             yield return new WaitForSeconds(1);
         }

--- a/Assets/Scenes/Night/Script/Manager/ItemManager.cs
+++ b/Assets/Scenes/Night/Script/Manager/ItemManager.cs
@@ -502,7 +502,7 @@ public class ItemManager : MonoBehaviour
             
             yield return new WaitUntil(() => character.ReturnCharacterShieldPoint() == 0);
             barriorScript.SetBarriorActive(false);
-
+            Debug.Log(timeCount);
             if (coolTimeImageArr[iconIdx].fillAmount == 0)
                 coolTimeImageArr[iconIdx].fillAmount = 1;
             StartCoroutine(SetCooltimeCoroutine(iconIdx, (float)timeCount));

--- a/Assets/Scenes/Night/Script/Manager/NightManager.cs
+++ b/Assets/Scenes/Night/Script/Manager/NightManager.cs
@@ -291,8 +291,10 @@ public class NightManager : MonoBehaviour
             {
                 Player player = GameManager.instance.player;
                 GameManager.instance.player.curExp += DataManager.instance.difficultyList.difficulty[nowDifficulty].rewardExp;
+                GameManager.instance.player.day = 1;
+                GameManager.instance.player.playingGame = false;
 
-                while(player.reqExp < player.curExp)
+                while (player.reqExp < player.curExp)
                 {
                     GameManager.instance.player.curExp -= GameManager.instance.player.reqExp;
                     GameManager.instance.player.level++;

--- a/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF.asset
+++ b/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF.asset
@@ -37,7 +37,7 @@ Material:
     - _PerspectiveFilter: 0.875
     - _ScaleRatioA: 0.9
     - _ScaleRatioB: 1
-    - _ScaleRatioC: 0.65925
+    - _ScaleRatioC: 0.65924996
     - _ScaleX: 1
     - _ScaleY: 1
     - _ShaderFlags: 0


### PR DESCRIPTION
해결된 부분

1. 7일 차 이후 day1로 다시 돌아가 컷 씬이 반복되어 보이지 않도록 수정
2. 몬스터가 이동 방향을 바라보도록 수정
3. 아래 바닥에 붙어서 이동할때 캐릭이 넘어지는 현상 수정
4. 캐릭터가 이동 방향을 바라보지 않는 이슈는 **확인 불가**
5. 베리어가 세션 안에서 다음 일차가 될 때 정상적으로 보호막이 되지 않는 다는 이슈는 **확인 불가** 1. 아래의 영상은 1~7일차까지 보호막이 있을 때를 가정한 영상입니다. 2. 마우스로 클릭한 shieldPoint 값은 공격력 5의 50%인 2.5로 동일한 수치 적용 중
7. 카메라 높이 25→ 30으로 수정(왼쪽 수정 전/ 오른쪽 수정 후)